### PR TITLE
Pool fix

### DIFF
--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -525,14 +525,13 @@ function SetupForPool(logger, poolOptions, setupFinished){
 
 
     var getProperAddress = function(address){
-        if (address.length === 40){
+        let result = address.match(xbtxAddrTemplate) || [];
+        if (result.length !== 0) {
+            return result[0];
+        } else if (address.length === 40) {
             return util.addressFromEx(poolOptions.address, address);
-        } else {
-            let result = address.match(xbtxAddrTemplate) || [];
-            if (result.length !== 0) {
-                return result[0];
-            }
         }
+
         return null; // only if address is not a valid xbtx address
     };
 

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -374,8 +374,6 @@ function SetupForPool(logger, poolOptions, setupFinished){
                                 logger.warning(logSystem, logComponent, 'Cannot send reward to invalid address '
                                 + w + '. Fix worker address in the database or enable address validation to disallow connection for invalid workers');
                             }
-                            worker.sent = addressAmounts[address] = satoshisToCoins(toSend);
-                            worker.balanceChange = Math.min(worker.balance, toSend) * -1;
                         }
                         else {
                             worker.balanceChange = Math.max(toSend - worker.balance, 0);

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -51,7 +51,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
     var logSystem = 'Payments';
     var xbtxAddrTemplate = /(R)[A-HJ-NP-Za-km-z1-9]{33}/
     var workerPerPaymentDefault = 10;
-    var maxWorkerPerPayment = processingConfig.maxWorkersPerPayment || workerPerPaymentDefault
+    var maxWorkerPerPayment = parseInt(processingConfig.maxWorkersPerPayment || workerPerPaymentDefault);
     var logComponent = coin;
 
     var daemon = new Stratum.daemon.interface([processingConfig.daemon], function(severity, message){

--- a/pool_configs/bitcoin-subsidium.json
+++ b/pool_configs/bitcoin-subsidium.json
@@ -10,6 +10,7 @@
     "paymentProcessing": {
         "enabled": true,
         "paymentInterval": 120,
+        "maxWorkersPerPayment": 10,
         "minimumPayment": 50,
         "daemon": {
             "host": "127.0.0.1",


### PR DESCRIPTION
I added xbtx address template:
- to parse valid address from redundand address-string such as 'RTLMGqQxkSJt2C9ooBvM5FyDqCMaivMvr4.3950X' and allow to pay rewards
- to log completely invalid addresses and not try to send rewards to them because 'sendmany' will fail anyway

Restriction on the maximum amount of workers per payment has been added.